### PR TITLE
fix: missing import leading to crash

### DIFF
--- a/repo/project.py
+++ b/repo/project.py
@@ -39,6 +39,7 @@ from repo.error import GitError, HookError, UploadError, DownloadError
 from repo.error import ManifestInvalidRevisionError, ManifestInvalidPathError
 from repo.error import NoManifestException
 from repo import platform_utils
+from repo import progress
 from repo.trace import IsTrace, Trace
 
 from repo.git_refs import GitRefs, HEAD, R_HEADS, R_TAGS, R_PUB, R_M, R_WORKTREE_M


### PR DESCRIPTION
error: Cannot checkout integ/platform_bootable_recovery.git: NameError: name 'progress' is not defined
Traceback (most recent call last):
  File "/home/user/.local/bin/repo", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/repo/main.py", line 642, in main
    return _Main(sys.argv[1:])
  File "/home/user/.local/lib/python3.6/site-packages/repo/main.py", line 617, in _Main
    result = run()
  File "/home/user/.local/lib/python3.6/site-packages/repo/main.py", line 610, in <lambda>
    run = lambda: repo._Run(name, gopts, argv) or 0
  File "/home/user/.local/lib/python3.6/site-packages/repo/main.py", line 262, in _Run
    result = cmd.Execute(copts, cargs)
  File "/home/user/.local/lib/python3.6/site-packages/repo/subcmds/sync.py", line 979, in Execute
    self._Checkout(all_projects, opt, err_event, err_results)
  File "/home/user/.local/lib/python3.6/site-packages/repo/subcmds/sync.py", line 567, in _Checkout
    self._CheckoutWorker(**kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/repo/subcmds/sync.py", line 447, in _CheckoutWorker
    return self._CheckoutOne(opt, project, *args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/repo/subcmds/sync.py", line 486, in _CheckoutOne
    success = syncbuf.Finish()
  File "/home/user/.local/lib/python3.6/site-packages/repo/project.py", line 3513, in Finish
    self._PrintMessages()
  File "/home/user/.local/lib/python3.6/site-packages/repo/project.py", line 3543, in _PrintMessages
    self.out.write(progress.CSI_ERASE_LINE)
NameError: name 'progress' is not defined